### PR TITLE
update symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.*",
+        "symfony/framework-bundle": ">=2.1",
         "ext-memcached": ">=1.0"
     },
     "autoload": {


### PR DESCRIPTION
Symfony\Component\Config\Definition\Builder\ScalarNodeDefinition::info() function called by /DependencyInjection/Configuration.php exists in symfony/Config 2.1 and greater, which is loaded only by symfony/framework 2.1 and greater
