### PR TITLE
Remove ext-memcached requirement from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1",
-        "ext-memcached": ">=1.0"
+        "symfony/framework-bundle": ">=2.1"
     },
     "autoload": {
         "psr-0": { "Lsw\\MemcacheBundle": "" }


### PR DESCRIPTION
Removing ext-memcached requirement from composer.json file allows developers that works on remote or virtual systems to be able to install/update this bundle.

For example I'm working on MacBook with standard PHP installation without any extension that my application require. Every change is submited to my virtual ubuntu server machine where I have all env ready to run app. Updating libs on virtual and sending them back is not really fancy solution ;-)
