### PR TITLE
Memcached options section missing

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -25,6 +25,7 @@ class Configuration implements ConfigurationInterface
             ->append($this->addSessionSupportSection())
             ->append($this->addDoctrineSection())
             ->append($this->addclientsSection())
+            ->append($this->addMemcachedOptionsSection())
         ;
 
         return $treeBuilder;


### PR DESCRIPTION
Memcached options section defined in addMemcachedOptionsSection() is never added to the TreeBuilder so the section is not available.
