### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ and a ```concurrency``` (default is 10). If you use one or more reverse proxies,
 ```yml
 lsw_memcache:
     firewall:
-        pool: firewall
+        pool: firewall   #set pool: null to dodge it
         prefix: "firewall_"
         concurrency: 10
         reverse_proxies: [10.0.0.1]


### PR DESCRIPTION
To fixed :  PHP Notice:  Undefined index: pool in vendor/leaseweb/memcache-bundle/Lsw/MemcacheBundle/DependencyInjection/LswMemcacheExtension.php on line 129 after composer update, we need to fixed firewall's pool at null. I don't know why he is ever call even if we don't call it in config.yml