### PR TITLE
fix: make it possible to use general stats

### DIFF
--- a/Cache/LoggingMemcache.php
+++ b/Cache/LoggingMemcache.php
@@ -158,7 +158,11 @@ class LoggingMemcache extends \MemcachePool implements MemcacheInterface, Loggin
             $arguments = array($type,$slabid,$limit);
         }
         list($_type,$_slabid,$_limit) = array($type,$slabid,$limit);
-        $result = parent::getStats($_type,$_slabid,$_limit);
+        if ($_type == '') {
+            $result = parent::getStats();
+        } else {
+            $result = parent::getStats($_type, $_slabid, $_limit);
+        }
         list($type,$slabid,$limit) = array($_type,$_slabid,$_limit);
         if ($this->logging) {
             $time = microtime(true) - $start;
@@ -173,7 +177,11 @@ class LoggingMemcache extends \MemcachePool implements MemcacheInterface, Loggin
             $arguments = array($type,$slabid,$limit);
         }
         list($_type,$_slabid,$_limit) = array($type,$slabid,$limit);
-        $result = parent::getExtendedStats($_type,$_slabid,$_limit);
+        if ($_type == '') {
+            $result = parent::getExtendedStats();
+        } else {
+            $result = parent::getExtendedStats($_type, $_slabid, $_limit);
+        }
         list($type,$slabid,$limit) = array($_type,$_slabid,$_limit);
         if ($this->logging) {
             $time = microtime(true) - $start;


### PR DESCRIPTION
Till now it wasnt possible to get the general stats of the memcached server. If you try to call the method 'getStats()' or 'getExtendedStats()' without a special $type you will get this warning: 

>Warning: MemcachePool::getextendedstats(): Invalid stats type

