### PR TITLE
Checking host before memcached addServer

### DIFF
--- a/DependencyInjection/LswMemcacheExtension.php
+++ b/DependencyInjection/LswMemcacheExtension.php
@@ -199,7 +199,9 @@ class LswMemcacheExtension extends Extension
                 $s['timeout'],
                 $s['retry_interval']
             );
-			$memcache->addMethodCall('addServer', $server);
+            if ($s['host']) {
+                $memcache->addMethodCall('addServer', $server);
+            }
         }
         
         $memcache->addArgument($config['options']);


### PR DESCRIPTION
I did this because my config in symfony2 env dev use one server with host equal to "localhost".
But in symfony2 env prod i need 2 servers with 2 differents hosts.
So i would like to have in my "paramter.yml" something like : 

# for dev server
server1.host: localhost
server2.host: null

# for prod servers
server1.host: 10.0.0.1
server2.host: 10.0.0.2

So i don't need to change the "config_prod.yml" file.

Maybe there's another way to do this, what is your opinion ?