### PR TITLE
Fix debug.yml for Symfony3 compatible

### DIFF
--- a/Resources/config/debug.yml
+++ b/Resources/config/debug.yml
@@ -4,6 +4,6 @@ parameters:
 
 services:
     memcache.data_collector:
-        class: %memcache.data_collector.class%
+        class: "%memcache.data_collector.class%"
         tags:
-            - { name: data_collector, template: %memcache.data_collector.template%, id:"memcache"}
+            - { name: data_collector, template: "%memcache.data_collector.template%", id:"memcache"}


### PR DESCRIPTION
Not quoting the scalar "%memcache.data_collector.class%" and "%memcache.data_collector.template%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0