### PR TITLE
Fix Deprecation with Symfony Yaml Component v3.2+

### DIFF
--- a/Resources/config/debug.yml
+++ b/Resources/config/debug.yml
@@ -6,4 +6,4 @@ services:
     memcache.data_collector:
         class: "%memcache.data_collector.class%"
         tags:
-            - { name: data_collector, template: "%memcache.data_collector.template%", id:"memcache"}
+            - { name: data_collector, template: "%memcache.data_collector.template%", id: "memcache" }


### PR DESCRIPTION
Fix syntax in debug.yml, that leads to a deprecation warning with Symfony 3.2+

> Using a colon that is not followed by an indication character (i.e. " ", ",", "[", "]", "{", "}" is deprecated since version 3.2 and will throw a ParseException in 4.0: 1x